### PR TITLE
Add Authentication Response Code checks

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -151,6 +150,10 @@ func host() string {
 	return fmt.Sprintf("http://%s", cfg.ListenAddr())
 }
 func TestHealthEndpointNoAuth(t *testing.T) {
+	if os.Getenv("KOITO_SKIP_DOCKER") == "1" {
+		t.Skip("skipping Docker-based integration test")
+	}
+
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
@@ -165,6 +168,10 @@ func TestHealthEndpointNoAuth(t *testing.T) {
 }
 
 func TestHealthEndpointMethodNotAllowed(t *testing.T) {
+	if os.Getenv("KOITO_SKIP_DOCKER") == "1" {
+		t.Skip("skipping Docker-based integration test")
+	}
+
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}


### PR DESCRIPTION
Closes https://github.com/Ian-J-S/Koito/issues/2

What changed:
Added TestAuthenticationBehavior integration test to verify authentication middleware correctly protects endpoints.

How to run the relevant tests:
To test entire engine:
go test ./engine -v
To run just this test:
go test ./engine -run TestAuthenticationBehavior -v

Evidence (what behavior is now protected / what would regress before)

    Any request to /apis/web/v1/stats (and other protected endpoints) without valid credentials receives a 401 Unauthorized response
    Requests with a valid session cookie successfully access the same protected endpoint with a 200 OK responseCloses https://github.com/Ian-J-S/Koito/issues/2

**What changed:**
Added TestAuthenticationBehavior integration test to verify authentication middleware correctly protects endpoints.

**How to run the relevant tests:**
To test entire engine:
`go test ./engine -v`
To run just this test:
`go test ./engine -run TestAuthenticationBehavior -v`

**Evidence (what behavior is now protected / what would regress before)**
- Any request to /apis/web/v1/stats (and other protected endpoints) without valid credentials receives a 401 Unauthorized response
- Requests with a valid session cookie successfully access the same protected endpoint with a 200 OK response