### PR TITLE
Add unit tests for romanizer. Closes #8.

### DIFF
--- a/romanizer/romanizer_test.go
+++ b/romanizer/romanizer_test.go
@@ -1,68 +1,181 @@
 package romanizer
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestRomanize(t *testing.T) {
+// --------------------
+// Basic / Latin Tests
+// --------------------
+
+func TestRomanize_Basic(t *testing.T) {
 	tests := []struct {
-		name     string
 		input    string
 		expected string
 	}{
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "whitespace only",
-			input:    "   ",
-			expected: "",
-		},
-		{
-			name:     "already latin",
-			input:    "Hello World",
-			expected: "",
-		},
-		{
-			name:     "latin with punctuation",
-			input:    "Hello, World!",
-			expected: "",
-		},
-		{
-			name:     "japanese",
-			input:    "こんにちは",
-			expected: "konnichiha",
-		},
-		{
-			name:     "korean",
-			input:    "안녕하세요",
-			expected: "annyeonghaseyo",
-		},
-		{
-			name:     "chinese",
-			input:    "你好",
-			expected: "Ni Hao",
-		},
-		{
-			name:     "mixed latin and japanese",
-			input:    "Hello 世界",
-			expected: "Hello Shi Jie",
-		},
-		{
-			name:     "leading and trailing whitespace",
-			input:    "   こんにちは   ",
-			expected: "konnichiha",
-		},
+		{"", ""},
+		{"   ", ""},
+		{"Hello World", ""},
+		{"Hello, World!", ""},
+		{"CSCI 630 - Koito", ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := Romanize(tt.input)
-			if result != tt.expected {
-				t.Errorf("Romanize(%q) = %q, expected %q", tt.input, result, tt.expected)
-			}
-		})
+		result := Romanize(tt.input)
+		if result != tt.expected {
+			t.Errorf("Romanize(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// --------------------
+// Japanese
+// --------------------
+
+func TestRomanize_Japanese(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"こんにちは", "konnichiha"},
+		{"   こんにちは   ", "konnichiha"},
+	}
+
+	for _, tt := range tests {
+		result := Romanize(tt.input)
+		if result != tt.expected {
+			t.Errorf("Romanize(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// --------------------
+// Korean
+// --------------------
+
+func TestRomanize_Korean(t *testing.T) {
+	result := Romanize("안녕하세요")
+	expected := "annyeonghaseyo"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "안녕하세요", result, expected)
+	}
+}
+
+// --------------------
+// Chinese
+// --------------------
+
+func TestRomanize_Chinese(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"你好", "Ni Hao"},
+		{"Hello 世界", "Hello Shi Jie"},
+	}
+
+	for _, tt := range tests {
+		result := Romanize(tt.input)
+		if result != tt.expected {
+			t.Errorf("Romanize(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// --------------------
+// Russian (Cyrillic)
+// --------------------
+
+func TestRomanize_Russian(t *testing.T) {
+	result := Romanize("Привет мир")
+	expected := "Privet mir"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "Привет мир", result, expected)
+	}
+}
+
+// --------------------
+// Greek
+// --------------------
+
+func TestRomanize_Greek(t *testing.T) {
+	result := Romanize("Γειά σου Κόσμε")
+	expected := "Geia sou Kosme"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "Γειά σου Κόσμε", result, expected)
+	}
+}
+
+// --------------------
+// Arabic
+// --------------------
+
+func TestRomanize_Arabic(t *testing.T) {
+	result := Romanize("مرحبا بالعالم")
+	expected := "mrHb bl`lm"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "مرحبا بالعالم", result, expected)
+	}
+}
+
+// --------------------
+// Hebrew
+// --------------------
+
+func TestRomanize_Hebrew(t *testing.T) {
+	result := Romanize("שלום עולם")
+	expected := "shlvm `vlm"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "שלום עולם", result, expected)
+	}
+}
+
+// --------------------
+// Hindi (Devanagari)
+// --------------------
+
+func TestRomanize_Hindi(t *testing.T) {
+	result := Romanize("नमस्ते")
+	expected := "nmste"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "नमस्ते", result, expected)
+	}
+}
+
+// --------------------
+// Thai
+// --------------------
+
+func TestRomanize_Thai(t *testing.T) {
+	result := Romanize("สวัสดี")
+	expected := "swasdii"
+
+	if result != expected {
+		t.Errorf("Romanize(%q) = %q, expected %q", "สวัสดี", result, expected)
+	}
+}
+
+// --------------------
+// Emoji / Symbols
+// --------------------
+
+func TestRomanize_Emoji(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"🙂", ""},
+		{"Hello 🙂", "Hello"},
+	}
+
+	for _, tt := range tests {
+		result := Romanize(tt.input)
+		if result != tt.expected {
+			t.Errorf("Romanize(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
 	}
 }


### PR DESCRIPTION
Closes #8

This will test romanizer.go. Currently, only supports for Asian texts, and other texts.
Got the help from CoPilot while creation of this unit test.

Please run: `go test ./romanizer` to execute the test.

This will prevent the following:
- If the program handles the conversion of the foreign texts to correct format.
- If the program does not accidentally alter the latin text to something else than expected. 