### PR TITLE
Add unit tests for logger Closes #10

### DIFF
--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestInjectAndFromContext(t *testing.T) {
+	var buf bytes.Buffer
+	testLogger := zerolog.New(&buf)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// Inject logger
+	req = Inject(req, &testLogger)
+
+	// Retrieve logger
+	l := FromContext(req.Context())
+
+	l.Info().Msg("hello")
+
+	output := buf.String()
+
+	if output == "" {
+		t.Fatal("expected log output, got empty string")
+	}
+
+	if !bytes.Contains([]byte(output), []byte("hello")) {
+		t.Errorf("expected log to contain 'hello', got %s", output)
+	}
+}


### PR DESCRIPTION
Closes #10

With the help of CoPilot, I have added these features to test the logger.go.

- Inject
- FromContext

Please run: `go test ./internal/logger` to run the test.

This will prevent the following:
- Having issues storing logs into selected location.
- Manage the correct logs and not return the incorrect logs that are stored.