### PR TITLE
P3 issue 65 database god object

### DIFF
--- a/engine/handlers/get_summary.go
+++ b/engine/handlers/get_summary.go
@@ -16,7 +16,7 @@ func SummaryHandler(store db.DB) http.HandlerFunc {
 		l.Debug().Msg("SummaryHandler: Received request to retrieve summary")
 		timeframe := TimeframeFromRequest(r)
 
-		summary, err := summary.GenerateSummary(ctx, store, summary.GenerateSummaryOpts{
+		summary, err := summary.GenerateSummary(ctx, summary.NewSummaryRepository(store), summary.GenerateSummaryOpts{
 			UserID:    1,
 			Timeframe: timeframe,
 			Title:     "",

--- a/internal/summary/repository.go
+++ b/internal/summary/repository.go
@@ -1,0 +1,68 @@
+package summary
+
+import (
+	"context"
+
+	"github.com/gabehf/koito/internal/db"
+	"github.com/gabehf/koito/internal/models"
+)
+
+type DBWrapper struct {
+	db db.DB
+}
+
+func NewSummaryRepository(db db.DB) SummaryRepository {
+	return &DBWrapper{db: db}
+}
+
+func (w *DBWrapper) GetTopArtistsPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Artist]], error) {
+	return w.db.GetTopArtistsPaginated(ctx, opts)
+}
+
+func (w *DBWrapper) GetTopAlbumsPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Album]], error) {
+	return w.db.GetTopAlbumsPaginated(ctx, opts)
+}
+
+func (w *DBWrapper) GetTopTracksPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Track]], error) {
+	return w.db.GetTopTracksPaginated(ctx, opts)
+}
+
+func (w *DBWrapper) CountTimeListenedToItem(ctx context.Context, opts db.TimeListenedOpts) (int64, error) {
+	return w.db.CountTimeListenedToItem(ctx, opts)
+}
+
+func (w *DBWrapper) CountListensToItem(ctx context.Context, opts db.TimeListenedOpts) (int64, error) {
+	return w.db.CountListensToItem(ctx, opts)
+}
+
+func (w *DBWrapper) CountTimeListened(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountTimeListened(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountListens(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountListens(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountTracks(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountTracks(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountAlbums(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountAlbums(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountArtists(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountArtists(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountNewTracks(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountNewTracks(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountNewAlbums(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountNewAlbums(ctx, timeframe)
+}
+
+func (w *DBWrapper) CountNewArtists(ctx context.Context, timeframe db.Timeframe) (int64, error) {
+	return w.db.CountNewArtists(ctx, timeframe)
+}

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -8,6 +8,22 @@ import (
 	"github.com/gabehf/koito/internal/models"
 )
 
+type SummaryRepository interface {
+	GetTopArtistsPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Artist]], error)
+	GetTopAlbumsPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Album]], error)
+	GetTopTracksPaginated(ctx context.Context, opts db.GetItemsOpts) (*db.PaginatedResponse[db.RankedItem[*models.Track]], error)
+	CountTimeListenedToItem(ctx context.Context, opts db.TimeListenedOpts) (int64, error)
+	CountListensToItem(ctx context.Context, opts db.TimeListenedOpts) (int64, error)
+	CountTimeListened(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountListens(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountTracks(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountAlbums(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountArtists(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountNewTracks(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountNewAlbums(ctx context.Context, timeframe db.Timeframe) (int64, error)
+	CountNewArtists(ctx context.Context, timeframe db.Timeframe) (int64, error)
+}
+
 type Summary struct {
 	Title            string                          `json:"title,omitempty"`
 	TopArtists       []db.RankedItem[*models.Artist] `json:"top_artists"` // ListenCount and TimeListened are overridden with stats from timeframe
@@ -31,7 +47,7 @@ type GenerateSummaryOpts struct {
 	Title     string
 }
 
-func GenerateSummary(ctx context.Context, store db.DB, opts GenerateSummaryOpts) (summary *Summary, err error) {
+func GenerateSummary(ctx context.Context, store SummaryRepository, opts GenerateSummaryOpts) (summary *Summary, err error) {
 	userId := opts.UserID
 	timeframe := opts.Timeframe
 	title := opts.Title


### PR DESCRIPTION
closes #65 

Changes made:
- Extracted a new summary.SummaryRepository interface to encapsulate summary-specific DB operations.
- Added summary.DBWrapper as a facade over db.DB, delegating only the methods needed by summary generation.
- Updated summary.GenerateSummary to depend on the smaller interface instead of the full db.DB.
- Updated get_summary.go to pass the facade-backed repository into summary generation.
- Preserved existing behavior while reducing summary module coupling to the broader database interface.