### PR TITLE
Refactor importers to use template

### DIFF
--- a/internal/importer/lastfm.go
+++ b/internal/importer/lastfm.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path"
 	"strconv"
 	"time"
 
@@ -96,76 +94,96 @@ func buildArtistMbidMap(artistName string, artistMBID uuid.UUID) []catalog.Artis
 	return []catalog.ArtistMbidMap{{Artist: artistName, Mbid: artistMBID}}
 }
 
-// buildSubmitListenOpts constructs the options for submitting a listen
-func buildSubmitListenOpts(track LastFMTrack, album string, albumMBID, artistMBID, trackMBID uuid.UUID, ts time.Time, mbzc mbz.MusicBrainzCaller) catalog.SubmitListenOpts {
-	artistMbidMap := buildArtistMbidMap(track.Artist.Text, artistMBID)
-	return catalog.SubmitListenOpts{
-		MbzCaller:          mbzc,
-		Artist:             track.Artist.Text,
-		ArtistNames:        []string{track.Artist.Text},
-		ArtistMbzIDs:       []uuid.UUID{artistMBID},
-		TrackTitle:         track.Name,
-		RecordingMbzID:     trackMBID,
-		ReleaseTitle:       album,
-		ReleaseMbzID:       albumMBID,
-		ArtistMbidMappings: artistMbidMap,
-		Client:             "lastfm",
-		Time:               ts,
-		UserID:             1,
-		SkipCacheImage:     !cfg.FetchImagesDuringImport(),
-	}
+// LastFMImporter implements the Importer interface for Last.fm exports.
+type LastFMImporter struct {
+	mbzc mbz.MusicBrainzCaller
 }
 
-func ImportLastFMFile(ctx context.Context, store db.DB, mbzc mbz.MusicBrainzCaller, filename string) error {
-	l := logger.FromContext(ctx)
-	l.Info().Msgf("Beginning LastFM import on file: %s", filename)
-	file, err := os.Open(path.Join(cfg.ConfigDir(), "import", filename))
-	if err != nil {
-		l.Err(err).Msgf("Failed to read import file: %s", filename)
-		return fmt.Errorf("ImportLastFMFile: %w", err)
-	}
-	defer file.Close()
-	var throttleFunc = func() {}
-	if ms := cfg.ThrottleImportMs(); ms > 0 {
-		throttleFunc = func() {
-			time.Sleep(time.Duration(ms) * time.Millisecond)
-		}
-	}
+// NewLastFMImporter creates a new Last.fm importer with the given MusicBrainz caller.
+func NewLastFMImporter(mbzc mbz.MusicBrainzCaller) *LastFMImporter {
+	return &LastFMImporter{mbzc: mbzc}
+}
+
+// Name returns the importer source name.
+func (l *LastFMImporter) Name() string {
+	return "lastfm"
+}
+
+// ParseRecords parses the Last.fm JSON export format.
+func (l *LastFMImporter) ParseRecords(data []byte) (interface{}, error) {
 	export := make([]LastFMExportPage, 0)
-	err = json.NewDecoder(file).Decode(&export)
+	err := json.Unmarshal(data, &export)
 	if err != nil {
-		return fmt.Errorf("ImportLastFMFile: %w", err)
+		return nil, fmt.Errorf("LastFMImporter.ParseRecords: %w", err)
 	}
+	return export, nil
+}
+
+// ProcessRecords iterates over Last.fm export pages and tracks, validates them, and processes valid entries.
+func (l *LastFMImporter) ProcessRecords(ctx context.Context, records interface{}, callback func(opts catalog.SubmitListenOpts) error) (int, error) {
+	logger := logger.FromContext(ctx)
+	export, ok := records.([]LastFMExportPage)
+	if !ok {
+		return 0, fmt.Errorf("LastFMImporter.ProcessRecords: invalid records type")
+	}
+
 	count := 0
-	for _, item := range export {
-		for _, track := range item.Track {
+	for _, page := range export {
+		for _, track := range page.Track {
+			// Validate track
 			if !validateTrack(track) {
-				l.Debug().Msg("Skipping invalid LastFM import item")
+				logger.Debug().Msg("Skipping invalid LastFM import item")
 				continue
 			}
 
+			// Normalize album name
 			album := normalizeAlbum(track.Album.Text, track.Name)
+
+			// Parse MBIDs
 			albumMBID, artistMBID, trackMBID := parseTrackMBIDs(track)
 
-			ts, ok := parseTrackTimestamp(track, l)
+			// Parse timestamp
+			ts, ok := parseTrackTimestamp(track, logger)
 			if !ok {
 				continue
 			}
 
+			// Check import time window
 			if !inImportTimeWindow(ts) {
-				l.Debug().Msgf("Skipping import due to import time rules")
+				logger.Debug().Msgf("Skipping import due to import time rules")
 				continue
 			}
 
-			opts := buildSubmitListenOpts(track, album, albumMBID, artistMBID, trackMBID, ts, mbzc)
-			err = catalog.SubmitListen(ctx, store, opts)
+			// Build options and process
+			artistMbidMap := buildArtistMbidMap(track.Artist.Text, artistMBID)
+			opts := catalog.SubmitListenOpts{
+				MbzCaller:          l.mbzc,
+				Artist:             track.Artist.Text,
+				ArtistNames:        []string{track.Artist.Text},
+				ArtistMbzIDs:       []uuid.UUID{artistMBID},
+				TrackTitle:         track.Name,
+				RecordingMbzID:     trackMBID,
+				ReleaseTitle:       album,
+				ReleaseMbzID:       albumMBID,
+				ArtistMbidMappings: artistMbidMap,
+				Client:             "lastfm",
+				Time:               ts,
+				UserID:             1,
+				SkipCacheImage:     !cfg.FetchImagesDuringImport(),
+			}
+
+			err := callback(opts)
 			if err != nil {
-				l.Err(err).Msg("Failed to import LastFM playback item")
-				return fmt.Errorf("ImportLastFMFile: %w", err)
+				return count, fmt.Errorf("LastFMImporter.ProcessRecords: %w", err)
 			}
 			count++
-			throttleFunc()
 		}
 	}
-	return finishImport(ctx, filename, count)
+
+	return count, nil
+}
+
+// ImportLastFMFile imports a Last.fm export file using the template workflow.
+func ImportLastFMFile(ctx context.Context, store db.DB, mbzc mbz.MusicBrainzCaller, filename string) error {
+	return ImportWithTemplate(ctx, store, filename, NewLastFMImporter(mbzc))
 }

--- a/internal/importer/maloja.go
+++ b/internal/importer/maloja.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 	"time"
 
@@ -32,45 +30,60 @@ type MalojaTrack struct {
 	} `json:"album"`
 }
 
-func ImportMalojaFile(ctx context.Context, store db.DB, filename string) error {
-	l := logger.FromContext(ctx)
-	l.Info().Msgf("Beginning maloja import on file: %s", filename)
-	file, err := os.Open(path.Join(cfg.ConfigDir(), "import", filename))
-	if err != nil {
-		l.Err(err).Msgf("Failed to read import file: %s", filename)
-		return fmt.Errorf("ImportMalojaFile: %w", err)
-	}
-	defer file.Close()
-	var throttleFunc = func() {}
-	if ms := cfg.ThrottleImportMs(); ms > 0 {
-		throttleFunc = func() {
-			time.Sleep(time.Duration(ms) * time.Millisecond)
-		}
-	}
+// MalojaImporter implements the Importer interface for Maloja exports.
+type MalojaImporter struct{}
+
+// Name returns the importer source name.
+func (m *MalojaImporter) Name() string {
+	return "maloja"
+}
+
+// ParseRecords parses the Maloja JSON export format.
+func (m *MalojaImporter) ParseRecords(data []byte) (interface{}, error) {
 	export := new(MalojaExport)
-	err = json.NewDecoder(file).Decode(&export)
+	err := json.Unmarshal(data, &export)
 	if err != nil {
-		return fmt.Errorf("ImportMalojaFile: %w", err)
+		return nil, fmt.Errorf("MalojaImporter.ParseRecords: %w", err)
 	}
+	return export, nil
+}
+
+// ProcessRecords iterates over Maloja scrobbles, validates them, and processes valid entries.
+func (m *MalojaImporter) ProcessRecords(ctx context.Context, records interface{}, callback func(opts catalog.SubmitListenOpts) error) (int, error) {
+	l := logger.FromContext(ctx)
+	export, ok := records.(*MalojaExport)
+	if !ok {
+		return 0, fmt.Errorf("MalojaImporter.ProcessRecords: invalid records type")
+	}
+
+	count := 0
 	for _, item := range export.Scrobbles {
-		martists := make([]string, 0)
-		// Maloja has a tendency to have the the artist order ['feature', 'main \u2022 feature'], so
-		// here we try to turn that artist array into ['main', 'feature']
-		item.Track.Artists = utils.MoveFirstMatchToFront(item.Track.Artists, " \u2022 ")
-		for _, an := range item.Track.Artists {
-			ans := strings.Split(an, " \u2022 ")
-			martists = append(martists, ans...)
-		}
-		artists := utils.UniqueIgnoringCase(martists)
+		// Skip invalid scrobbles
 		if len(item.Track.Artists) < 1 || item.Track.Title == "" {
 			l.Debug().Msg("Skipping invalid maloja import item")
 			continue
 		}
+
+		// Parse timestamp
 		ts := time.Unix(item.Time, 0)
+
+		// Check import time window
 		if !inImportTimeWindow(ts) {
 			l.Debug().Msgf("Skipping import due to import time rules")
 			continue
 		}
+
+		// Process artist names: Maloja sometimes has artist arrays like ['feature', 'main • feature'],
+		// so we normalize and deduplicate them.
+		martists := make([]string, 0)
+		artists := item.Track.Artists
+		artists = utils.MoveFirstMatchToFront(artists, " • ")
+		for _, an := range artists {
+			ans := strings.Split(an, " • ")
+			martists = append(martists, ans...)
+		}
+		artists = utils.UniqueIgnoringCase(martists)
+
 		opts := catalog.SubmitListenOpts{
 			MbzCaller:      &mbz.MusicBrainzClient{},
 			Artist:         item.Track.Artists[0],
@@ -82,12 +95,18 @@ func ImportMalojaFile(ctx context.Context, store db.DB, filename string) error {
 			UserID:         1,
 			SkipCacheImage: !cfg.FetchImagesDuringImport(),
 		}
-		err = catalog.SubmitListen(ctx, store, opts)
+
+		err := callback(opts)
 		if err != nil {
-			l.Err(err).Msg("Failed to import maloja playback item")
-			return fmt.Errorf("ImportMalojaFile: %w", err)
+			return count, fmt.Errorf("MalojaImporter.ProcessRecords: %w", err)
 		}
-		throttleFunc()
+		count++
 	}
-	return finishImport(ctx, filename, len(export.Scrobbles))
+
+	return count, nil
+}
+
+// ImportMalojaFile imports a Maloja export file using the template workflow.
+func ImportMalojaFile(ctx context.Context, store db.DB, filename string) error {
+	return ImportWithTemplate(ctx, store, filename, &MalojaImporter{})
 }

--- a/internal/importer/spotify.go
+++ b/internal/importer/spotify.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path"
 	"time"
 
 	"github.com/gabehf/koito/internal/catalog"
@@ -24,57 +22,74 @@ type SpotifyExportItem struct {
 	MsPlayed   int32     `json:"ms_played"`
 }
 
-func ImportSpotifyFile(ctx context.Context, store db.DB, filename string) error {
-	l := logger.FromContext(ctx)
-	l.Info().Msgf("Beginning spotify import on file: %s", filename)
-	file, err := os.Open(path.Join(cfg.ConfigDir(), "import", filename))
-	if err != nil {
-		l.Err(err).Msgf("Failed to read import file: %s", filename)
-		return fmt.Errorf("ImportSpotifyFile: %w", err)
-	}
-	defer file.Close()
-	var throttleFunc = func() {}
-	if ms := cfg.ThrottleImportMs(); ms > 0 {
-		throttleFunc = func() {
-			time.Sleep(time.Duration(ms) * time.Millisecond)
-		}
-	}
+// SpotifyImporter implements the Importer interface for Spotify exports.
+type SpotifyImporter struct{}
+
+// Name returns the importer source name.
+func (s *SpotifyImporter) Name() string {
+	return "spotify"
+}
+
+// ParseRecords parses the Spotify JSON export format.
+func (s *SpotifyImporter) ParseRecords(data []byte) (interface{}, error) {
 	export := make([]SpotifyExportItem, 0)
-	err = json.NewDecoder(file).Decode(&export)
+	err := json.Unmarshal(data, &export)
 	if err != nil {
-		return fmt.Errorf("ImportSpotifyFile: %w", err)
+		return nil, fmt.Errorf("SpotifyImporter.ParseRecords: %w", err)
+	}
+	return export, nil
+}
+
+// ProcessRecords iterates over Spotify export items, validates them, and processes valid entries.
+func (s *SpotifyImporter) ProcessRecords(ctx context.Context, records interface{}, callback func(opts catalog.SubmitListenOpts) error) (int, error) {
+	l := logger.FromContext(ctx)
+	export, ok := records.([]SpotifyExportItem)
+	if !ok {
+		return 0, fmt.Errorf("SpotifyImporter.ProcessRecords: invalid records type")
 	}
 
+	count := 0
 	for _, item := range export {
+		// Skip items that weren't fully played
 		if item.ReasonEnd != "trackdone" {
 			continue
 		}
+
+		// Check import time window
 		if !inImportTimeWindow(item.Timestamp) {
 			l.Debug().Msgf("Skipping import due to import time rules")
 			continue
 		}
-		dur := item.MsPlayed
+
+		// Skip invalid tracks
 		if item.TrackName == "" || item.ArtistName == "" {
 			l.Debug().Msg("Skipping non-track item")
 			continue
 		}
+
 		opts := catalog.SubmitListenOpts{
 			MbzCaller:      &mbz.MusicBrainzClient{},
 			Artist:         item.ArtistName,
 			TrackTitle:     item.TrackName,
 			ReleaseTitle:   item.AlbumName,
-			Duration:       dur / 1000,
+			Duration:       item.MsPlayed / 1000,
 			Time:           item.Timestamp,
 			Client:         "spotify",
 			UserID:         1,
 			SkipCacheImage: !cfg.FetchImagesDuringImport(),
 		}
-		err = catalog.SubmitListen(ctx, store, opts)
+
+		err := callback(opts)
 		if err != nil {
-			l.Err(err).Msg("Failed to import spotify playback item")
-			return fmt.Errorf("ImportSpotifyFile: %w", err)
+			return count, fmt.Errorf("SpotifyImporter.ProcessRecords: %w", err)
 		}
-		throttleFunc()
+		count++
 	}
-	return finishImport(ctx, filename, len(export))
+
+	return count, nil
+}
+
+// ImportSpotifyFile imports a Spotify export file using the template workflow.
+func ImportSpotifyFile(ctx context.Context, store db.DB, filename string) error {
+	return ImportWithTemplate(ctx, store, filename, &SpotifyImporter{})
 }

--- a/internal/importer/template.go
+++ b/internal/importer/template.go
@@ -1,0 +1,99 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"time"
+
+	"github.com/gabehf/koito/internal/catalog"
+	"github.com/gabehf/koito/internal/cfg"
+	"github.com/gabehf/koito/internal/db"
+	"github.com/gabehf/koito/internal/logger"
+)
+
+// Importer defines the interface for source-specific import logic.
+// Implementations should focus only on parsing and mapping, while the template
+// handles the common workflow (file handling, iteration, submission, throttling).
+type Importer interface {
+	// Name returns the human-readable name of the importer source
+	Name() string
+
+	// ParseRecords reads and parses the raw data from the file.
+	// It should return a slice of parsed records ready for iteration.
+	ParseRecords([]byte) (interface{}, error)
+
+	// ProcessRecords takes the parsed records and yields individual items
+	// to be processed. It handles validation, filtering, and mapping to SubmitListenOpts.
+	// The callback should return true if the item was successfully processed, false to skip.
+	ProcessRecords(ctx context.Context, records interface{}, callback func(opts catalog.SubmitListenOpts) error) (int, error)
+}
+
+// ImportWithTemplate provides the common import workflow for all importers.
+// It handles:
+// - File opening and reading
+// - Throttling
+// - Error handling
+// - Completion tracking
+//
+// Importers only need to implement record parsing and mapping logic.
+func ImportWithTemplate(ctx context.Context, store db.DB, filename string, importer Importer) error {
+	l := logger.FromContext(ctx)
+	l.Info().Msgf("Beginning %s import on file: %s", importer.Name(), filename)
+
+	// Open and read the file
+	file, err := os.Open(path.Join(cfg.ConfigDir(), "import", filename))
+	if err != nil {
+		l.Err(err).Msgf("Failed to read import file: %s", filename)
+		return fmt.Errorf("ImportWithTemplate: %w", err)
+	}
+	defer file.Close()
+
+	// Read file contents
+	fileContent := make([]byte, 0)
+	buffer := make([]byte, 4096)
+	for {
+		n, err := file.Read(buffer)
+		if n > 0 {
+			fileContent = append(fileContent, buffer[:n]...)
+		}
+		if err != nil {
+			if err.Error() != "EOF" {
+				return fmt.Errorf("ImportWithTemplate: %w", err)
+			}
+			break
+		}
+	}
+
+	// Parse records using importer-specific logic
+	records, err := importer.ParseRecords(fileContent)
+	if err != nil {
+		return fmt.Errorf("ImportWithTemplate: %w", err)
+	}
+
+	// Setup throttling
+	throttleFunc := func() {}
+	if ms := cfg.ThrottleImportMs(); ms > 0 {
+		throttleFunc = func() {
+			time.Sleep(time.Duration(ms) * time.Millisecond)
+		}
+	}
+
+	// Process records
+	count, err := importer.ProcessRecords(ctx, records, func(opts catalog.SubmitListenOpts) error {
+		err := catalog.SubmitListen(ctx, store, opts)
+		if err != nil {
+			l.Err(err).Msgf("Failed to import %s playback item", importer.Name())
+			return err
+		}
+		throttleFunc()
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("ImportWithTemplate: %w", err)
+	}
+
+	return finishImport(ctx, filename, count)
+}


### PR DESCRIPTION
closes #62 

Changes made:
Created template.go:
- Importer interface with Name(), ParseRecords(), and ProcessRecords() methods
- ImportWithTemplate() function handles common workflow: file I/O, throttling, error handling, completion

- Spotify, Maloja, Last.fm: Created structs implementing the Importer interface
- Moved format-specific parsing and mapping to ParseRecords() and ProcessRecords()
- Simplified main import functions to delegate to template workflow