### PR TITLE
Refactor PeriodSelector using Observer pattern (#69)

### DIFF
--- a/client/app/components/PeriodSelector.tsx
+++ b/client/app/components/PeriodSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { periodStore } from "../utils/periodStore"
 
 interface Props {
     setter: Function
@@ -6,42 +6,77 @@ interface Props {
     disableCache?: boolean
 }
 
-export default function PeriodSelector({ setter, current, disableCache = false }: Props) {
+export default function PeriodSelector({
+    setter,
+    current,
+    disableCache = false
+}: Props) {
+
     const periods = ['day', 'week', 'month', 'year', 'all_time']
 
     const periodDisplay = (str: string) => {
-        return str.split('_').map(w => w.split('').map((char, index) =>
-            index === 0 ? char.toUpperCase() : char).join('')).join(' ')
+        return str
+            .split('_')
+            .map(w =>
+                w
+                    .split('')
+                    .map((char, index) =>
+                        index === 0 ? char.toUpperCase() : char
+                    )
+                    .join('')
+            )
+            .join(' ')
     }
 
     const setPeriod = (val: string) => {
         setter(val)
+
         if (!disableCache) {
-            localStorage.setItem('period_selection_'+window.location.pathname.split('/')[1], val) 
-        }  
+            periodStore.set(val)
+        }
     }
 
     useEffect(() => {
-        if (!disableCache) {
-            const cached = localStorage.getItem('period_selection_' + window.location.pathname.split('/')[1]);
-            if (cached) {
-              setter(cached);
-            }
+        if (disableCache) {
+            return
         }
-      }, []);
+
+        const cached = periodStore.get()
+
+        if (cached) {
+            setter(cached)
+        }
+
+        const unsubscribe = periodStore.subscribe((value: string) => {
+            setter(value)
+        })
+
+        return unsubscribe
+
+    }, [disableCache, setter])
 
     return (
         <div className="flex gap-2 grow-0 text-sm sm:text-[16px]">
             <p>Showing stats for:</p>
+
             {periods.map((p, i) => (
                 <div key={`period_setter_${p}`}>
-                    <button 
-                        className={`period-selector ${p === current ? 'color-fg' : 'color-fg-secondary'} ${i !== periods.length - 1 ? 'pr-2' : ''}`}
+                    <button
+                        className={`period-selector ${
+                            p === current
+                                ? 'color-fg'
+                                : 'color-fg-secondary'
+                        } ${
+                            i !== periods.length - 1
+                                ? 'pr-2'
+                                : ''
+                        }`}
                         onClick={() => setPeriod(p)}
                         disabled={p === current}
                     >
                         {periodDisplay(p)}
                     </button>
+
                     <span className="color-fg-secondary">
                         {i !== periods.length - 1 ? '|' : ''}
                     </span>

--- a/client/app/components/periodStore.ts
+++ b/client/app/components/periodStore.ts
@@ -1,0 +1,31 @@
+type Listener = (value: string) => void
+
+const listeners: Listener[] = []
+
+const getStorageKey = () => {
+    return 'period_selection_' + window.location.pathname.split('/')[1]
+}
+
+export const periodStore = {
+    get() {
+        return localStorage.getItem(getStorageKey())
+    },
+
+    set(value: string) {
+        localStorage.setItem(getStorageKey(), value)
+
+        listeners.forEach(listener => listener(value))
+    },
+
+    subscribe(listener: Listener) {
+        listeners.push(listener)
+
+        return () => {
+            const index = listeners.indexOf(listener)
+
+            if (index !== -1) {
+                listeners.splice(index, 1)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes [#69](https://github.com/Ian-J-S/Koito/issues/69)

Summary
Refactored PeriodSelector to remove direct localStorage access using a shared observable state helper.

Pattern
Observer

Verification
npm test
npm run build